### PR TITLE
Fix video frame extraction and preview issues in ASCII animation workflow

### DIFF
--- a/src/components/controls/ControlVideoSettings.js
+++ b/src/components/controls/ControlVideoSettings.js
@@ -20,84 +20,99 @@ export default function ControlVideoSettings({
   const [nativeFramerate, setNativeFramerate] = useState(null);
   const [frames, setFrames] = useState([]);
   const [animationFrameCount, setAnimationFrameCount] = useState(null);
+  const [currentProcessingFrame, setCurrentProcessingFrame] = useState(null);
 
-  // load video and process frames
   useEffect(() => {
     async function processVideo() {
-      // load file and create file url
       let videoBlob = await fetch(sourceVideo[0].data.src).then((r) => r.blob());
       let videoUrl = URL.createObjectURL(videoBlob);
       setVideoUrl(videoUrl);
 
-      // get video duration
       let vid = document.createElement('video');
-      vid.src = videoUrl; 
+      vid.src = videoUrl;
       vid.ondurationchange = function () { setVideoDuration(this.duration); }
 
-      // revoke URL to prevent memory leak
       URL.revokeObjectURL(videoBlob);
 
-      // update loading message
       setVideoUploadIsLoading(true);
       setUploadMessage("Loading frames...");
 
-      // set up canvas
-      let canvas = document.querySelector("#video-upload");
-      let ctx = canvas.getContext("2d");
-
-      // process video frames
       let frames = [];
       let i = -1;
+      let processedFrameCount = 0;
+      let canvasWidth = 0;
+      let canvasHeight = 0;
+
       await getVideoFrames({
         videoUrl,
-        onFrame(frame) {  // `frame` is a VideoFrame object: https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame
+        onFrame(frame) {
           i++;
-          if (i !== 0 && i % 5 !== 0) return;
+          if (i !== 0 && i % 5 !== 0) {
+            frame.close();
+            return;
+          }
+
+          let canvas = document.createElement('canvas');
+          let ctx = canvas.getContext("2d");
+
+          canvas.width = canvasWidth;
+          canvas.height = canvasHeight;
+
+          processedFrameCount++;
+          setUploadMessage(`Processing frame ${processedFrameCount}...`);
+
           ctx.drawImage(frame, 0, 0, canvas.width, canvas.height);
           let image = document.createElement("img");
           image.width = canvas.width;
           image.height = canvas.height;
           image.src = canvas.toDataURL();
-          frames.push({data: image});
+
+          setCurrentProcessingFrame(image.src);
+
+          frames.push({ data: image });
           frame.close();
         },
         onConfig(config) {
-          canvas.width = config.codedWidth / 2;
-          canvas.height = config.codedHeight / 2;
+          canvasWidth = config.codedWidth / 2;
+          canvasHeight = config.codedHeight / 2;
         },
       });
 
-      // update loading message to include frames
-      let frameCount = i + 2;
+      let frameCount = i + 1;
       let nativeFramerate = Math.floor((frameCount) / vid.duration);
       setFrames(frames);
       setFrameCount(frameCount);
       setNativeFramerate(nativeFramerate);
       setAnimationFramerate(nativeFramerate / 2);
-      setUploadMessage(`Loaded ${frameCount} frames...`);
-      setAnimationFrameCount(Math.floor(frameCount / 4));
+      setUploadMessage(`Loaded ${frames.length} frames from ${frameCount} total frames...`);
+      setAnimationFrameCount(Math.floor(frames.length / 4));
+      setVideoUploadIsLoading(false);
     }
 
     processVideo();
   }, []);
 
-  // convert video frames into animation frames
   const createAnimationFrames = () => {
-    // update global state
     let animationFrames = getDistributedSubarray(frames, animationFrameCount);
     setSelectedFrame(0);
     setSourceImages(animationFrames);
     updateAsciiStrings(draft => draft = new Array(animationFrames.length).fill("").map(str => str));
     setModalOpen(false);
   }
-  
-  return(
+
+  return (
     <div className="flex flex-col gap-y-3 item-start justify-start border border-dashed border-[black] p-4 max-w-[350px] bg-white">
       <p>
         Source video: {sourceVideo[0].filename}
       </p>
 
-      <canvas id="video-upload" className="max-w-[300px]" />
+      {(currentProcessingFrame || (frames.length > 0 && frames[0]?.data?.src)) && (
+        <img
+          src={currentProcessingFrame || frames[0].data.src}
+          className="max-w-[300px]"
+          alt="Video frame preview"
+        />
+      )}
 
       {uploadMessage && (
         <p>
@@ -124,7 +139,7 @@ export default function ControlVideoSettings({
             name="number-of-animation-frames"
             unit=" frames"
             min={1}
-            max={frameCount}
+            max={frames.length || frameCount}
             step={1}
             value={animationFrameCount}
             onChange={setAnimationFrameCount}
@@ -137,10 +152,10 @@ export default function ControlVideoSettings({
         </>
       )}
 
-      {frameCount && (
+      {frames.length > 0 && (
         <button onClick={createAnimationFrames}>
           Create animation frames and close
-        </button> 
+        </button>
       )}
     </div>
   )


### PR DESCRIPTION
# Summary of Changes

This PR fixes issues related to incorrect thumbnail previews and broken ASCII output caused by improper video frame handling.

## What I changed:
- Replaced shared global canvas with a new canvas created for each frame to prevent frame overwrites
- Moved canvas dimension setup into the onConfig callback to ensure correct sizing per frame
- Added currentProcessingFrame state to show real-time preview of frames being processed
- Ensured each VideoFrame is properly closed to avoid memory leaks
- Updated preview rendering logic in the UI to reflect actual processing state

## Why I changed it:
- Previously, all frames were drawn to the same canvas (#video-upload), resulting in only the last processed frame being visible
- This caused both the frame previews and the final ASCII output to appear static or incorrect
- By isolating canvas usage and improving UI feedback, frame-by-frame accuracy and performance are both improved

## How to test:
1.	Upload a video file
2.	Watch for correct frame-by-frame preview updates
3.	Ensure the resulting ASCII animation reflects actual video content changes


![螢幕錄影 2025-05-26 22 58 22](https://github.com/user-attachments/assets/e3136715-92d7-4e5d-a80a-0f52cdf72f1d)

BTW your project is sooooooo dope
